### PR TITLE
Replace onrendered by then Promise

### DIFF
--- a/src/js/positive.js
+++ b/src/js/positive.js
@@ -210,13 +210,12 @@
                 settings.onScreenshotLoad();
                 settings.showLoader($(previewSelector, $screenshotPlaceholder));
                 html2canvas(document.body, {
-                    onrendered: function (canvas) {
-                        callback(canvas);
-                        settings.onScreenshotLoaded();
-                        settings.hideLoader($(previewSelector, $screenshotPlaceholder));
-                    },
                     width: window.screen.availWidth,
                     height: window.screen.availHeight
+                }).then(function (canvas) {
+                       callback(canvas);
+                       settings.onScreenshotLoaded();
+                       settings.hideLoader($(previewSelector, $screenshotPlaceholder));
                 });
             }
         };


### PR DESCRIPTION
Hi, 
I've been testing positive.js and it seems that the usage of html2canvas is broken since version 0.5.0. (https://github.com/niklasvh/html2canvas/issues/674#issuecomment-138589870)

This is a small fix to repair it. Hopes this helps.